### PR TITLE
Change analog clock hour hand to move

### DIFF
--- a/src/sidebar-card.ts
+++ b/src/sidebar-card.ts
@@ -107,7 +107,7 @@ class SidebarCard extends LitElement {
     const minutes = date.getMinutes();
     const seconds = date.getSeconds();
     
-    const hour = hours * 30;
+    const hour = Math.floor((hours * 60 + minutes) / 2);
     const minute = minutes * 6;
     const second = seconds * 6;
     


### PR DESCRIPTION
Made a simple change to make the hour hand of the analog clock move proportionally through the hour by calculating the total number of minutes passed since midnight out of the total number in 12 hours and using that as the number of degrees to rotate (ie hours * 60 + minutes / 720 * 360 -> h * 60 + m / 2). 