### PR TITLE
Update sidebar-card.js & README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ views:
 
 ### Main Options
 
-Under sidebar you can configur the following options
+Under sidebar you can configure the following options:
 
 | Name | Type | Default | Supported options | Description |
 | -------------- | ----------- | ------------ | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -51,6 +51,7 @@ Under sidebar you can configur the following options
 | `digitalClock` | boolean | optional | `true` | Show digital clock in sidebar |
 | `digitalClockWithSeconds` | boolean | optional | `true` | If digitalClock is enabled you can also enable to show seconds |
 | `twelveHourVersion` | boolean | optional | `false` | If digitalClock is enabled you can also enable this to 12 hour version |
+| `showPeriod` | boolean | optional | `false` | If twelveHourVersion is enabled you can enable this to show 'AM' or 'PM' |
 | `date` | boolean | optional | `false` | If date is enabled it will display the current date |
 | `dateFormat` | boolean | string | `DD MMMM` | If date is enabled you define how it should show the date with dateFormat, to see the options check this url: https://momentjs.com/docs/#/parsing/string-format/ |
 | `width` | object | optional | see info below | The width of the sidebar in percentages for different screens |

--- a/dist/sidebar-card.js
+++ b/dist/sidebar-card.js
@@ -17662,6 +17662,7 @@ class SidebarCard extends LitElement {
         this.digitalClock = false;
         this.twelveHourVersion = false;
         this.digitalClockWithSeconds = false;
+        this.viewPeriod = false;
         this.date = false;
         this.dateFormat = "DD MMMM";
         this.bottomCard = null;
@@ -17681,6 +17682,7 @@ class SidebarCard extends LitElement {
         this.digitalClock = this.config.digitalClock ? this.config.digitalClock : false;
         this.digitalClockWithSeconds = this.config.digitalClockWithSeconds ? this.config.digitalClockWithSeconds : false;
         this.twelveHourVersion = this.config.twelveHourVersion ? this.config.twelveHourVersion : false;
+        this.viewPeriod = this.config.viewPeriod ? this.config.viewPeriod : false;
         this.date = this.config.date ? this.config.date : false;
         this.dateFormat = this.config.dateFormat ? this.config.dateFormat : "DD MMMM";
         this.bottomCard = this.config.bottomCard ? this.config.bottomCard : null;
@@ -17738,6 +17740,7 @@ class SidebarCard extends LitElement {
     _runClock() {
         const date = new Date();
         var fullhours = date.getHours().toString();
+        const realhours = date.getHours();
         const hours = ((date.getHours() + 11) % 12 + 1);
         const minutes = date.getMinutes();
         const seconds = date.getSeconds();
@@ -17762,8 +17765,26 @@ class SidebarCard extends LitElement {
             }
             this.shadowRoot.querySelector('.digitalClock').textContent = digitalTime;
         }
-        else if (this.digitalClock && this.twelveHourVersion) {
-            var ampm = hours >= 12 ? 'pm' : 'am';
+        else if (this.digitalClock && this.twelveHourVersion && !this.viewPeriod) {
+            var hoursampm = date.getHours();
+            hoursampm = hoursampm % 12;
+            hoursampm = hoursampm ? hoursampm : 12;
+            fullhours = hoursampm.toString();
+            const minutesString = minutes.toString();
+            var digitalTime = fullhours.length < 2 ? '0' + fullhours + ':' : fullhours + ':';
+            if (this.digitalClockWithSeconds) {
+                digitalTime += minutesString.length < 2 ? '0' + minutesString + ':' : minutesString + ':';
+                const secondsString = seconds.toString();
+                digitalTime += secondsString.length < 2 ? '0' + secondsString : secondsString;
+            }
+            else {
+                digitalTime += minutesString.length < 2 ? '0' + minutesString : minutesString;
+            }
+            digitalTime;
+            this.shadowRoot.querySelector('.digitalClock').textContent = digitalTime;
+        }
+        else if (this.digitalClock && this.twelveHourVersion && this.viewPeriod) {
+            var ampm = realhours >= 12 ? 'pm' : 'am';
             var hoursampm = date.getHours();
             hoursampm = hoursampm % 12;
             hoursampm = hoursampm ? hoursampm : 12;


### PR DESCRIPTION
Sidebar-card.js was updated to fix the 12 hour clocks period, to indicate `am` or `pm` correctly. `showPeriod` was also added so the period can be hidden or shown.

The readme was updatedd to include the `showPeriod` in the options table.

Fixes dbuit/sidebar-card#19