### PR TITLE
Update the calculation of the header (top space) / fixes 2 issues

### DIFF
--- a/dist/sidebar-card.js
+++ b/dist/sidebar-card.js
@@ -18635,7 +18635,7 @@ function getHeaderHeightPx() {
     const view = root.shadowRoot.getElementById('view');
 	//debugger;
 	if(view!==undefined && window.getComputedStyle(view)!==undefined) {
-		headerHeightPx = window.getComputedStyle(view).marginTop;
+		headerHeightPx = window.getComputedStyle(view).paddingTop;
 	}
     return headerHeightPx;
 }

--- a/src/sidebar-card.ts
+++ b/src/sidebar-card.ts
@@ -846,7 +846,7 @@ function getHeaderHeightPx() {
     const view = root.shadowRoot.getElementById('view');
 	//debugger;
 	if(view!==undefined && window.getComputedStyle(view)!==undefined) {
-		headerHeightPx = window.getComputedStyle(view).marginTop;
+		headerHeightPx = window.getComputedStyle(view).paddingTop;
 	}
     return headerHeightPx;
 }


### PR DESCRIPTION
Update the calculation of the header (top space) to determine the "top" of sidebar element: Consider the padding-top instead of margin-top.

Resolve the 2 issues:
- https://github.com/DBuit/sidebar-card/issues/89
- https://github.com/DBuit/sidebar-card/issues/99

Tested on with and without kiosk-mode on:
- smartphone (HA app)
- Tablet 10' (chrome + HA app + fully kiosk browser)
- PC (Firefox)