### PR TITLE
Fixing the resize on bigger screen

### DIFF
--- a/src/sidebar-card.ts
+++ b/src/sidebar-card.ts
@@ -282,7 +282,9 @@ class SidebarCard extends LitElement {
     window.addEventListener(
       'resize',
       function() {
-        self.updateSidebarSize(root);
+        setTimeout(() => {
+          self.updateSidebarSize(root);
+        }, 1);
       },
       true
     );


### PR DESCRIPTION
Hello,

I've observed that the resize function doesn't work properly when using a larger resolution screen or a phone with more than 1080p resolution.

This is the problem I've been encountering:

![ezgif-5-b991a0e2b7](https://github.com/DBuit/sidebar-card/assets/33904836/4dec6b7a-bde7-4844-bfd1-c74210120c50)

I actually found out that by adding the timeout delay inside the resize event, it fixes the problem.
